### PR TITLE
Switch back to using a decorator.

### DIFF
--- a/BruteBuster/__init__.py
+++ b/BruteBuster/__init__.py
@@ -4,10 +4,10 @@ Module preventing Brute Force attacks against
 django.contrib.auth.authenticate()
 """
 
-version = '0.2.1'
+version = '0.2.2'
 
 # from django.contrib import auth
 # from BruteBuster.decorators import protect_and_serve
-# 
+#  
 # # here we override the default authenticate method with the decorated version
 # auth.authenticate = protect_and_serve(auth.authenticate)

--- a/BruteBuster/decorators.py
+++ b/BruteBuster/decorators.py
@@ -1,11 +1,27 @@
-from django.contrib.auth.backends import ModelBackend
 from BruteBuster.models import FailedAttempt
 from BruteBuster.middleware import get_request
 from django.core.exceptions import ValidationError
 
 
-class RateLimitingBackend(ModelBackend):
-    def authenticate(self, username=None, password=None):
+def get_username(**kwargs):
+    return kwargs['username']
+
+def protect_and_serve(auth_func, get_username=get_username):
+    """
+    This is the main code of the application. It is meant to replace the
+    authentication() function, with one that records failed login attempts and
+    blocks logins, if a threshold is reached
+    """
+
+    if hasattr(auth_func, '__BB_PROTECTED__'):
+        # avoiding multiple decorations
+        return auth_func
+
+    def decor(*args, **kwargs):
+        user = get_username(**kwargs)
+        if not user:
+            raise ValueError('BruteBuster could not find a username in the authenticate kwargs')
+        
         request = get_request()
         if request:
             # try to get the remote address from thread locals
@@ -20,7 +36,7 @@ class RateLimitingBackend(ModelBackend):
             IP_ADDR = None
 
         try:
-            fa = FailedAttempt.objects.filter(username=username, IP=IP_ADDR)[0]
+            fa = FailedAttempt.objects.filter(username=user, IP=IP_ADDR)[0]
             if fa.recent_failure():
                 if fa.too_many_failures():
                     # we block the authentication attempt because
@@ -40,16 +56,19 @@ class RateLimitingBackend(ModelBackend):
             # No previous failed attempts
             fa = None
 
-        user = super(RateLimitingBackend, self).authenticate(username,
-                                                             password)
-        if user:
+        result = auth_func(*args, **kwargs)
+        if result:
             # the authentication was successful - we do nothing
             # special
-            return user
+            return result
 
         # the authentication was kaput, we should record this
-        fa = fa or FailedAttempt(username=username, IP=IP_ADDR, failures=0)
+        fa = fa or FailedAttempt(username=user, IP=IP_ADDR, failures=0)
         fa.failures += 1
         fa.save()
         # return with unsuccessful auth
         return None
+    
+    decor.__BB_PROTECTED__ = True
+    return decor
+    

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: django-brutebuster
-Version: 0.1.8
+Version: 0.2.2
 Summary: Pluggable Django application providing password bruteforce protection
 Home-page: http://code.google.com/p/django-brutebuster/
 Author: Cyber Security Consulting Ltd.

--- a/django_brutebuster.egg-info/PKG-INFO
+++ b/django_brutebuster.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: django-brutebuster
-Version: 0.2.1
+Version: 0.2.2
 Summary: Pluggable Django application providing password bruteforce protection
 Home-page: http://code.google.com/p/django-brutebuster/
 Author: Cyber Security Consulting Ltd.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(\
     name = "django-brutebuster",
-    version = "0.2.1",
+    version = "0.2.2",
     packages = find_packages(),
     author = "Cyber Security Consulting Ltd.",
     author_email = "contact@csc.bg",


### PR DESCRIPTION
There is no need to use a custom authentication backend to display a validation error message. A ValidationError can be thrown out of the decorated authenticate method as well.

Allow clients to specify how the username should be extracted from the authenticate kwargs.
